### PR TITLE
Selling below cost 

### DIFF
--- a/CRUD-API/lib/DataTypes/product/index.js
+++ b/CRUD-API/lib/DataTypes/product/index.js
@@ -75,9 +75,9 @@ class Product {
       /**Round to the 100th decimal. n.n55 === n.n6 */
 
       const price = this.sellAtList
-         ? this.listPrice
-         : roundTwoDecimal(this.cost * this.markup);
-      return price;
+        ? this.listPrice
+        : Math.max(roundTwoDecimal(this.cost * this.markup), roundTwoDecimal(this.cost * this.markdown));
+    return price;
    }
 }
 


### PR DESCRIPTION

- The price is calculated as the maximum value between the price calculated using the markup (cost * markup) and the price calculated using the markdown (cost * markdown). This ensures that the price is at least equal to the cost price.

- The roundTwoDecimal function is applied to both the markup and the markdown prices to ensure they are rounded to two decimal places.

- The Math.max function is used to select the higher of the two prices calculated using markup and markdown.

- This modification allows for selling the product below the cost price if markdown is set appropriately.


